### PR TITLE
Version check too fuzzy

### DIFF
--- a/ghe-check-hotpatch.sh
+++ b/ghe-check-hotpatch.sh
@@ -58,7 +58,7 @@ sanity_check () {
   API_VERSION=$(curl -s http://localhost:1337/api/v3/meta | jq .installed_version | tr '"' ' ' | xargs)
 
   echo "Checking if API version matches expected version:"
-  if [[ "$PATCH_VERSION" == "$API_VERSION"* ]]
+  if [[ "$PATCH_VERSION" == "$API_VERSION" ]]
   then
     echo "API version matches expected version."
   else


### PR DESCRIPTION
`[[ "$PATCH_VERSION" == "$API_VERSION"* ]]` will erroneously match `PATCH_VERSION` `1.2.3` with `API_VERSION` `1.2.30`