### PR TITLE
Labels backwards

### DIFF
--- a/ghe-check-hotpatch.sh
+++ b/ghe-check-hotpatch.sh
@@ -109,7 +109,7 @@ verify_running_image_tags () {
     then 
       echo "$s is running on the expected hash."
     else
-      echo "$s is running on the wrong hash! Got: $EXPECTED_TAG Expected: $RUNNING_TAG!"
+      echo "$s is running on the wrong hash! Got: $RUNNING_TAG Expected: $EXPECTED_TAG!"
       export FAILURE_STATUS=true
     fi
   done


### PR DESCRIPTION
Running and expected labels backwards in error:

The following error is observed, where:
  - `EXPECTED_TAG` is `eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
  - `RUNNING_TAG` is `e2b48b7bd57bcb23aa2593936f8d116f52b79e4e`

```
pages is running on the wrong hash! Got: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee Expected: e2b48b7bd57bcb23aa2593936f8d116f52b79e4e!
```